### PR TITLE
Fix cross_validation import error on python 2.7

### DIFF
--- a/download-and-convert-cifar-10.py
+++ b/download-and-convert-cifar-10.py
@@ -4,6 +4,7 @@ from subprocess import call
 
 import numpy as np
 import sklearn
+import sklearn.cross_validation
 import sklearn.linear_model
 
 import h5py

--- a/download-and-convert-cifar-100.py
+++ b/download-and-convert-cifar-100.py
@@ -4,6 +4,7 @@ from subprocess import call
 
 import numpy as np
 import sklearn
+import sklearn.cross_validation
 import sklearn.linear_model
 
 import h5py


### PR DESCRIPTION
explicitly import cross_validation to avoid error: https://stackoverflow.com/questions/16743889/cant-use-scikit-learn-attributeerror-module-object-has-no-attribute